### PR TITLE
Add required plugin dependencies to theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -16,6 +16,17 @@ add_filter('rest_endpoints', function ($endpoints) {
     return $endpoints;
 });
 
+// Register required plugin dependencies for the theme.
+add_action('after_setup_theme', function () {
+    if (function_exists('wp_register_plugin_theme_dependencies')) {
+        wp_register_plugin_theme_dependencies([
+            'advanced-custom-fields',
+            'wp-rest-api-v2-menus',
+            'wordpress-seo',
+        ]);
+    }
+});
+
 // ─────────────────────────────────────────────────────────────
 // Block editor styles + patterns
 // ─────────────────────────────────────────────────────────────

--- a/style.css
+++ b/style.css
@@ -6,4 +6,5 @@ Description: A custom WordPress theme for use with headless frontends. Does not 
 Version: 1.0
 License: GNU General Public License v2 or later
 Text Domain: hydrated-headless
+Requires Plugins: advanced-custom-fields, wp-rest-api-v2-menus, wordpress-seo
 */


### PR DESCRIPTION
## Summary
- declare Advanced Custom Fields, WP-REST-API V2 Menus, and Yoast SEO as required theme plugins via the theme header metadata
- register the required plugin dependencies programmatically during theme setup for WordPress sites that support it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc80e91ce483249398cb9a26fbb7a0